### PR TITLE
some fixes for the build system

### DIFF
--- a/make/buildsystem-prerequisites.mk
+++ b/make/buildsystem-prerequisites.mk
@@ -30,7 +30,7 @@ find-%:
 		{ $(call WARNING,"Warning",": required tool $$TOOL missing."); false; }
 
 bashcheck:
-	@test "$(subst /bin/,,$(shell readlink /bin/sh))" == "bash" || \
+	@test "$(findstring /bash,$(shell readlink -f /bin/sh))" == "/bash" || \
 		{ $(call WARNING,"Warning",": /bin/sh is not linked to bash"); false; }
 
 toolcheck: bashcheck $(TOOLCHECK)

--- a/make/target-rootfs.mk
+++ b/make/target-rootfs.mk
@@ -144,7 +144,7 @@ ifneq ($(DEBUG),yes)
 	@echo "The following warnings from strip are harmless!"
 	@$(call draw_line);
 	for dir in $(ROOTFS_STRIP_BINS); do \
-		find $(ROOTFS_DIR)$${dir} -type f -print0 | xargs -0 $(TARGET_STRIP) || true; \
+		find $(ROOTFS_DIR)$${dir} -type f -print0 | xargs -n 128 -0 $(TARGET_STRIP) || true; \
 	done
 	for dir in $(ROOTFS_STRIP_LIBS); do \
 		find $(ROOTFS_DIR)$${dir} \( \
@@ -153,7 +153,7 @@ ifneq ($(DEBUG),yes)
 				-path $(ROOTFS_DIR)/lib/libv3ddriver.so -o \
 				\
 				-path $(ROOTFS_DIR)/lib/modules \) -prune -o \
-		-type f -print0 | xargs -0 $(TARGET_STRIP) || true; \
+		-type f -print0 | xargs -n 128 -0 $(TARGET_STRIP) || true; \
 	done
   ifeq ($(BOXSERIES),hd2)
 	find $(ROOTFS_DIR)/lib/modules/$(KERNEL_VERSION)/kernel -type f -name '*.ko' | xargs -n 1 $(TARGET_OBJCOPY) --strip-unneeded

--- a/package/pkg-utils.mk
+++ b/package/pkg-utils.mk
@@ -690,7 +690,8 @@ endef
 # rewrite libtool libraries
 REWRITE_LIBTOOL_RULES = "\
 	s,^libdir=.*,libdir='$(1)',; \
-	s,\(^dependency_libs='\| \|-L\|^dependency_libs='\)/lib,\ $(1),g"
+	s,\(^dependency_libs='\| \|-L\|^dependency_libs='\)/lib,\ $(1),; \
+	/^dependency_libs=/s, /usr/lib/lib\([^ ]*\).la, -l\1,g; "
 
 REWRITE_LIBTOOL_TAG = rewritten=1
 


### PR DESCRIPTION
Bei dem rewrite-more-host-paths bin ich mir nicht sicher, ob das die beste Lösung ist.
Viele andere lib.la haben im "dependency_libs=" den vollen Pfad ins target drin, aber einige halt auch zum  host (/usr/lib/foo.la).
Ob es jetzt richtiger ist, den vollen Pfad ins /pfad/zum/bs/root/usr/lib/foo.la da rein zu schreiben oder einfach -lfoo, da bin ich mir nicht sicher.

Jedenfalls baut es somit auch ohne unnötiges (und falsches) devel-zeug auf dem Host ;-)